### PR TITLE
Fix batch submission script

### DIFF
--- a/src/cc_hdnnp/controller.py
+++ b/src/cc_hdnnp/controller.py
@@ -715,7 +715,7 @@ class Controller:
               - exclusive
               - commands
         """
-        commands = self.qe_module_commands
+        commands = self.qe_module_commands.copy()
         commands += [
             "n=$SLURM_NTASKS",
             "export OMP_NUM_THREADS=1",


### PR DESCRIPTION
Resolves #18 

The current behaviour of `prepare_qe` appears to leave no spaces between the end of one command (`.slurm`) and the start of the next (`sbatch`) in `qe_all.sh`, so this adds a new line between each submission command to fix this.

Also added a fix to prevent duplication of commands, both when `prepare_qe` is run repeatedly, and between different `.slurm` files, as described in #18.