### PR TITLE
Sets the default pbc to t t t when writing dataset

### DIFF
--- a/src/cc_hdnnp/dataset.py
+++ b/src/cc_hdnnp/dataset.py
@@ -571,6 +571,7 @@ class Dataset(List[Frame]):
                 ):
                     frames.append(
                         Frame(
+                            pbc = atoms.get_pbc(),
                             lattice=atoms.cell,
                             symbols=atoms.symbols,
                             positions=atoms.positions,


### PR DESCRIPTION
Sets the default pbc to t t t when writing dataset. Maybe should try to read the pbc from the file