### PR TITLE
Add options when plotting histograms

### DIFF
--- a/src/cc_hdnnp/visualisation.py
+++ b/src/cc_hdnnp/visualisation.py
@@ -677,6 +677,8 @@ def plot_data_histogram(
     superimpose: bool = True,
     alpha: float = 1.0,
     density: bool = False,
+    ec: str = None,
+    histtype: str = "bar",
 ):
     """
     Plots the energy and force values present in a series of reference datasets. This can be
@@ -703,6 +705,10 @@ def plot_data_histogram(
         Sets the transparency of the plotted bars. `1.0` is opaque. Optional, default is `1.0`.
     density: bool = False
         Whether to plot the probability density. Optional, default is `False`.
+    ec: str = None
+        Edge colour of histogram. Optional, default is `None`.
+    histtype: str = "bar"
+        Type of histogram to draw. Optional, default is "bar".
     """
     n_rows = 1 if superimpose else len(data_files)
     energies = []
@@ -734,14 +740,14 @@ def plot_data_histogram(
             force_position = 2 * i + 2
 
         plt.subplot(n_rows, 2, energy_position)
-        plt.hist(energies[i], bins=bins, range=(energy_min, energy_max), alpha=alpha, density=density)
+        plt.hist(energies[i], bins=bins, range=(energy_min, energy_max), alpha=alpha, density=density, ec=ec, histtype=histtype)
         plt.xlabel("Energy")
         plt.yscale(energy_scale)
         plt.title("Reference Energies ({})".format(data_file))
         plt.legend(data_files)
 
         plt.subplot(n_rows, 2, force_position)
-        plt.hist(forces[i], bins=bins, range=(force_min, force_max), alpha=alpha, density=density)
+        plt.hist(forces[i], bins=bins, range=(force_min, force_max), alpha=alpha, density=density, ec=ec, histtype=histtype)
         plt.xlabel("Force")
         plt.yscale(force_scale)
         plt.title("Reference Forces ({})".format(data_file))


### PR DESCRIPTION
Adds an option for the density of energy and force histograms, to improve comparisons between different sized datasets. Set to false by default for consistency with previous behaviour.

Also adds typing to alpha for consistency, and options for histogram type and edge colour, which can be useful when the histograms have significant overlap.