### PR TITLE
Add missing argument

### DIFF
--- a/examples/example_directory/scripts/workflow.ipynb
+++ b/examples/example_directory/scripts/workflow.ipynb
@@ -416,7 +416,7 @@
     ")\n",
     "\n",
     "a = ActiveLearning(data_controller=al_controller)\n",
-    "a.write_lammps()"
+    "a.write_lammps(temperatures=[300])"
    ]
   },
   {


### PR DESCRIPTION
Adds an example argument to `ActiveLearning.write_lammps`, as this is required.