### PR TITLE
Fix AL directory and run command

### DIFF
--- a/src/cc_hdnnp/controller.py
+++ b/src/cc_hdnnp/controller.py
@@ -1529,9 +1529,9 @@ class Controller:
                 "path=$(sed -n ${SLURM_ARRAY_TASK_ID}p ${SLURM_SUBMIT_DIR}/"
                 f"{self.active_learning_directory}/joblist_mode1.dat)"
             ),
-            "cd ../active_learning/mode1/$path",
+            f"cd ../{self.active_learning_directory}/mode1/$path",
             (
-                "srun "
+                "mpirun -np ${SLURM_NTASKS} "
                 f"{self.lammps_executable} -in input.lammps -screen none"
             )
         ]


### PR DESCRIPTION
Fixes the active learning path, and reverts a change to use `mpirun` rather than `srun`, for more flexibility in the number of tasks.