### PR TITLE
Fix active learning path

### DIFF
--- a/src/cc_hdnnp/controller.py
+++ b/src/cc_hdnnp/controller.py
@@ -1546,7 +1546,7 @@ class Controller:
                 "path=$(sed -n ${SLURM_ARRAY_TASK_ID}p ${SLURM_SUBMIT_DIR}/"
                 f"{self.active_learning_directory}/joblist_mode1.dat)"
             ),
-            f"cd ../{self.active_learning_directory}/mode1/$path",
+            f"cd {self.active_learning_directory}/mode1/$path",
             (
                 "mpirun -np ${SLURM_NTASKS} "
                 f"{self.lammps_executable} -in input.lammps -screen none"


### PR DESCRIPTION
`self.active_learning_directory` is defined as `join_paths(main_directory, active_learning_sub_directory)`, so prepending with `..` is not necessary (and inconsistent with its use elsewhere, e.g. the line above).