### PR TITLE
Fix large job arrays

### DIFF
--- a/src/cc_hdnnp/controller.py
+++ b/src/cc_hdnnp/controller.py
@@ -1546,6 +1546,8 @@ class Controller:
         """
         submit_all_text = ""
 
+        if n_simulations < 1:
+            raise ValueError("`n_simulations` must be at least 1.")
         if n_simulations % 1000 == 0:
             num_scripts = n_simulations // 1000
         else:
@@ -1588,8 +1590,9 @@ class Controller:
         if num_scripts > 1:
             with open(join_paths(self.scripts_directory, file_batch_out), "w") as f:
                 f.write(submit_all_text)
-
-        return f"sbatch {file_batch_out}"
+            return f"bash {file_batch_out}"
+        else:
+            return f"sbatch {file_batch_out}"
 
     def _write_active_learning_nn_script(
         self,


### PR DESCRIPTION
Resolves #30 when writing `active_learning_lammps.sh`.

For arrays <= 1000, the script created should essentially be unchanged. For larger arrays, the same script (`active_learning_lammps.sh`) instead submits multiple other scripts, similar to `qe_all.sh`.

This could potentially be implemented more generally, but currently only this script and CP2K jobs have any realistic chance of encountering this issue. It may be worth considering whether similar changes may be useful in `controller.write_cp2k`.

Note: may require rebasing due to #31. 