### PR TITLE
Add kwargs for lammps input

### DIFF
--- a/src/cc_hdnnp/controller.py
+++ b/src/cc_hdnnp/controller.py
@@ -1789,6 +1789,7 @@ class Controller:
         temperatures: Iterable[int] = (300,),
         n_steps: Iterable[str] = (10000,),
         file_batch_out: str = "lammps_extrapolations.sh",
+        lammps_kwargs: Dict = {},
         **kwargs,
     ):
         """
@@ -1817,6 +1818,8 @@ class Controller:
         file_batch_out: str, optional
             File location to write the batch script to relative to
             `scripts_sub_directory`. Default is 'lammps_extrapolations.sh'.
+        lammps_kwargs: Dict
+            Dictionary of keyword arguments to be passed to `format_lammps_input`.
         **kwargs:
             Used to set optional str arguments for the batch script:
               - constraint
@@ -1842,6 +1845,7 @@ class Controller:
             elements=" ".join(self.all_structures.element_list_alphabetical),
             n_steps=n_steps,
             temps=temperatures,
+            **lammps_kwargs,
         )
 
         commands = self.n2p2_module_commands + [


### PR DESCRIPTION
Resolves #42

Implemented in the same way as #40, including a minor fix to both to prevent errors if no kwargs dictionary is passed.

Beyond the scope of this PR, but it would likely be useful to convert more (all?) `format_lammps_input` arguments into interables, e.g. to allow different values for `tdamp` for different temperatures.