### PR TITLE
Fixed error in plot for inputs with different numbers of atoms

### DIFF
--- a/src/cc_hdnnp/visualisation.py
+++ b/src/cc_hdnnp/visualisation.py
@@ -716,7 +716,7 @@ def plot_data_histogram(
     for i, data_file in enumerate(data_files):
         data = Dataset(data_file=data_file)
         energy = data.all_energies
-        force = data.all_forces.flatten()
+        force = np.concatenate(data.all_forces, axis=0).flatten()
         if i == 0:
             energy_min = min(energy)
             energy_max = max(energy)


### PR DESCRIPTION
Changed the way the data structure containing all the forces is flattened in the plot_data_histogram function to accomodate dataset containing configurations with different numbers of atoms