### PR TITLE
Remove None QE options

### DIFF
--- a/src/cc_hdnnp/controller.py
+++ b/src/cc_hdnnp/controller.py
@@ -607,7 +607,7 @@ class Controller:
                 'mixing_beta'       : 0.25,
                 'startingwfc'       : 'atomic+random',
                 'startingpot'       : 'atomic',
-                'nbnd'              : 400,
+                'nbnd'              : None,
                 'ecutwfc'           : 80,
                 'ecutrho'           : 480,
                 'input_dft'         : 'VDW-DF2-B86R',
@@ -630,7 +630,7 @@ class Controller:
             "mixing_beta": 0.25,
             "startingwfc": "atomic+random",
             "startingpot": "atomic",
-            "nbnd": 400,
+            "nbnd": None,
             "ecutwfc": 80,
             "ecutrho": 480,
             "input_dft": "VDW-DF2-B86R",
@@ -653,6 +653,10 @@ class Controller:
                     "options: {}".format(key, value, list(options))
                 )
             options[key] = value
+
+        for key, value in options.copy().items():
+            if value is None:
+                options.pop(key)
 
         write(
             filename=join_paths(frame_directory, "{}.in".format(structure.name)),


### PR DESCRIPTION
Removes `nbnd` from Quantum Espresso input files by default through changing its default value to `None`, in combination with removing `options` keys with values of `None`.

Values of `"none"` will still be passed, and `nbnd` remains an option that can be set via `qe_kwargs`.

Note: This requires the fix introduced in #43 to prevent errors if no `qe_kwargs` are passed.