### PR TITLE
Update dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3441,4 +3441,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "52cc571f0ff9f54d6d0e915ff287b3503b0684f3e5a645e4d11e1098308b9c6d"
+content-hash = "204dfeca82178b8fb1ff3cfda548baef6deeed0adba3f7934bf1710a7037561c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Patrick Austin <patrick.austin@stfc.ac.uk>"]
 [tool.poetry.dependencies]
 aml = {path = "../aml", develop = true}
 ase = "^3.22.0"
+fonttools = ">=4.43.0"
 ipykernel = "^6.0.3"
 ipython = "8.10"
 joblib = "1.2"


### PR DESCRIPTION
Update urllib3, GitPython, pillow and fonttools to address [security issues](https://github.com/stfc/CC_HDNNP/security/dependabot).

Also replaces the [deprecated sklearn](https://pypi.org/project/sklearn/) with scikit-learn, and replaces hardcoded version for jupyter-core.